### PR TITLE
feat: add language as a new arg to use in the scripts

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -9,8 +9,10 @@ const args = require('yargs')
 .alias('h', 'help')
 .alias('c', 'city')
 .alias('r', 'relation')
+.alias('lang', 'language')
 .describe('c', 'City in your data folder')
 .describe('r', 'OSM relation ID for that city')
+.describe('lang', 'main language of the streets names')
 .demandOption(['c', 'r']).argv;
 
 function printArgs() {
@@ -25,12 +27,13 @@ async function startProcess() {
 	printArgs();
 	const city = args.city ? args.city : 'city';
 	const relationIdOSM = args.relation ? args.relation : 1;
+	const language = args.language ? args.language : 'es';
 	
-	const getStreetsResult = await processCity(city, relationIdOSM);
+	const getStreetsResult = await processCity(city, relationIdOSM, language);
 	if(!getStreetsResult) return;
 
 	console.log('--------------------- Start applying gender...');
-	await applyGender(city);
+	await applyGender(city, [language]);
 	
 
 }


### PR DESCRIPTION
Added lang as a new arg to be used to filter and to process the streets in a specific language.

For now, the available languages to be used are:
- ca --> catalan
- es --> spanish

Add a new language, requiere the previous addition of its corresponding street prefixes dictionary. 
i.e. for spanish: Calle, avenida, Camino...